### PR TITLE
Fixed weird include in php71-hash

### DIFF
--- a/security/php71-hash/Makefile
+++ b/security/php71-hash/Makefile
@@ -1,0 +1,10 @@
+# Created by: Alex Dupre <ale@FreeBSD.org>
+# $FreeBSD$
+
+CATEGORIES=	security
+
+MASTERDIR=	${.CURDIR}/../../lang/php71
+
+PKGNAMESUFFIX=	-hash
+
+.include "${MASTERDIR}/Makefile"

--- a/security/php71-hash/files/patch-php__hash__sha3.h
+++ b/security/php71-hash/files/patch-php__hash__sha3.h
@@ -1,0 +1,11 @@
+--- php_hash_sha3.h.orig	2016-11-09 03:34:27 UTC
++++ php_hash_sha3.h
+@@ -20,7 +20,7 @@
+ #define PHP_HASH_SHA3_H
+ 
+ #include "php.h"
+-#include "ext/hash/php_hash.h"
++#include "php_hash.h"
+ 
+ typedef struct {
+ 	unsigned char state[200]; // 5 * 5 * sizeof(uint64)


### PR DESCRIPTION
Unsure if fixing the include line in php_hash_sha3.h is the right way to go about it (Maybe the include paths should be looked at instead?), but it works!